### PR TITLE
fix: create ecr repository on tag too

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,7 @@ steps:
       - name: cache
         path: /go
     settings:
+      create_repository: true
       registry: public.ecr.aws/kanopy
       repo: ${DRONE_REPO_NAME}
       tags:


### PR DESCRIPTION
As the repository wasn't active in Drone when merging the first commit, the repository wasn't created