### PR TITLE
fix: grafana-admin-toggle

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -36,7 +36,7 @@ func TestTokenValidations(t *testing.T) {
 	defer backendServer.Close()
 	backendURL, _ := url.Parse(backendServer.URL)
 
-	client := grafana.NewMockClient(gapi.User{Login: "jhon"}, map[int64]models.RoleType{})
+	client := grafana.NewMockClient(gapi.User{Login: "jhon", ID: 1}, map[int64]models.RoleType{})
 
 	tests := []struct {
 		name       string
@@ -129,7 +129,7 @@ func TestHandleRoot(t *testing.T) {
 		1: models.ROLE_EDITOR,
 	}
 
-	client := grafana.NewMockClient(gapi.User{Login: "jhon"}, orgRoleMap)
+	client := grafana.NewMockClient(gapi.User{Login: "jhon", ID: 1}, orgRoleMap)
 
 	server, err := New(
 		WithGrafanaProxyURL(backendURL),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -36,7 +36,7 @@ func TestTokenValidations(t *testing.T) {
 	defer backendServer.Close()
 	backendURL, _ := url.Parse(backendServer.URL)
 
-	client := grafana.NewMockClient(gapi.User{Login: "jhon", ID: 1}, map[int64]models.RoleType{})
+	client := grafana.NewMockClient(&gapi.User{Login: "jhon", ID: 1}, map[int64]models.RoleType{})
 
 	tests := []struct {
 		name       string
@@ -129,7 +129,7 @@ func TestHandleRoot(t *testing.T) {
 		1: models.ROLE_EDITOR,
 	}
 
-	client := grafana.NewMockClient(gapi.User{Login: "jhon", ID: 1}, orgRoleMap)
+	client := grafana.NewMockClient(&gapi.User{Login: "jhon", ID: 1}, orgRoleMap)
 
 	server, err := New(
 		WithGrafanaProxyURL(backendURL),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -36,7 +36,7 @@ func TestTokenValidations(t *testing.T) {
 	defer backendServer.Close()
 	backendURL, _ := url.Parse(backendServer.URL)
 
-	client := grafana.NewMockClient(&gapi.User{Login: "jhon", ID: 1}, map[int64]models.RoleType{})
+	client := grafana.NewMockClient(gapi.User{Login: "jhon", ID: 1}, map[int64]models.RoleType{})
 
 	tests := []struct {
 		name       string
@@ -129,7 +129,7 @@ func TestHandleRoot(t *testing.T) {
 		1: models.ROLE_EDITOR,
 	}
 
-	client := grafana.NewMockClient(&gapi.User{Login: "jhon", ID: 1}, orgRoleMap)
+	client := grafana.NewMockClient(gapi.User{Login: "jhon", ID: 1}, orgRoleMap)
 
 	server, err := New(
 		WithGrafanaProxyURL(backendURL),

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -146,9 +146,12 @@ func (c *Client) UpdateOrgUserAuthz(user gapi.User, groups config.Groups) (userO
 		}
 	}
 
-	err := c.UpdateUserPermissions(user.ID, isGlobalAdmin)
-	if err != nil {
-		return userOrgsRole, err
+	// only update global admin value if it's different to what the user already have
+	if user.IsAdmin != isGlobalAdmin {
+		err := c.UpdateUserPermissions(user.ID, isGlobalAdmin)
+		if err != nil {
+			return userOrgsRole, err
+		}
 	}
 
 	return userOrgsRole, nil

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -124,29 +124,17 @@ func (c *Client) UpdateUserPermissions(id int64, isAdmin bool) error {
 	return c.client.UpdateUserPermissions(id, isAdmin)
 }
 
-func (c *Client) updateUserGrafanaAdmin(user gapi.User, isAdmin bool) error {
-	if isAdmin != user.IsAdmin {
-		err := c.UpdateUserPermissions(user.ID, isAdmin)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // UpdateOrgUserAuthz updates both roles and global admin status for a user
 // taking into account group configuration. It outputs a mapping of role-in-org
 // it will return an error when there's an issue updating the GrafanaAdmin permissions
 func (c *Client) UpdateOrgUserAuthz(user gapi.User, groups config.Groups) (userOrgsRoleMap, error) {
 	// Mapping of role per org
 	userOrgsRole := make(userOrgsRoleMap)
+	var isGlobalAdmin bool
 
 	for _, group := range groups {
-		err := c.updateUserGrafanaAdmin(user, group.GrafanaAdmin)
-		if err != nil {
-			return userOrgsRole, err
-		}
+		// resolve grafana global admin
+		isGlobalAdmin = isGlobalAdmin || group.GrafanaAdmin
 
 		for _, org := range group.Orgs {
 			// Check if the users has a more permissive role and apply that instead
@@ -156,6 +144,11 @@ func (c *Client) UpdateOrgUserAuthz(user gapi.User, groups config.Groups) (userO
 
 			userOrgsRole[org.ID] = models.RoleType(org.Role)
 		}
+	}
+
+	err := c.UpdateUserPermissions(user.ID, isGlobalAdmin)
+	if err != nil {
+		return userOrgsRole, err
 	}
 
 	return userOrgsRole, nil

--- a/pkg/grafana/client_test.go
+++ b/pkg/grafana/client_test.go
@@ -21,7 +21,7 @@ func newUser(login string, id int64) gapi.User {
 func TestLookupUser(t *testing.T) {
 	user := newUser("foo", 1)
 
-	client := NewMockClient(user, nil)
+	client := NewMockClient(&user, nil)
 
 	foundUser, err := client.LookupUser(user.Login)
 	assert.Nil(t, err)
@@ -35,7 +35,7 @@ func TestLookupUser(t *testing.T) {
 func TestCreateUser(t *testing.T) {
 	user := newUser("foo", 1)
 
-	client := NewMockClient(user, nil)
+	client := NewMockClient(&user, nil)
 
 	uid, err := client.CreateUser(user)
 	assert.Nil(t, err)
@@ -48,7 +48,7 @@ func TestAddOrgUser(t *testing.T) {
 	orgRoleMap := userOrgsRoleMap{
 		1: models.ROLE_EDITOR,
 	}
-	client := NewMockClient(user, orgRoleMap)
+	client := NewMockClient(&user, orgRoleMap)
 
 	// test adding to new org
 	err := client.AddOrgUser(2, "foo", "Editor")
@@ -66,7 +66,7 @@ func TestUpsertOrgUser(t *testing.T) {
 		1: models.ROLE_EDITOR,
 	}
 
-	client := NewMockClient(user, orgRoleMap)
+	client := NewMockClient(&user, orgRoleMap)
 
 	// this should always succeed except for errors when calling the rest api
 	err := client.UpsertOrgUser(1, user, "Editor")
@@ -85,7 +85,7 @@ func TestUpsertOrgUser(t *testing.T) {
 func TestUpdateUserPermissions(t *testing.T) {
 	user := newUser("foo", 1)
 
-	client := NewMockClient(user, userOrgsRoleMap{})
+	client := NewMockClient(&user, userOrgsRoleMap{})
 
 	err := client.UpdateUserPermissions(user.ID, true)
 	assert.NoError(t, err)
@@ -183,7 +183,7 @@ func TestGetOrCreateUser(t *testing.T) {
 	// Existing user
 	user := newUser("foo", 1)
 
-	client := NewMockClient(user, userOrgsRoleMap{})
+	client := NewMockClient(&user, userOrgsRoleMap{})
 
 	orgUser, err := client.GetOrCreateUser("foo")
 	assert.NoError(t, err)

--- a/pkg/grafana/client_test.go
+++ b/pkg/grafana/client_test.go
@@ -143,10 +143,13 @@ func TestUpdateOrgUserAuthz(t *testing.T) {
 			expected: userOrgsRoleMap{1: "Admin"},
 		},
 		// Using user id 0 forces an error in UpdateUserPermissions
+		// GrafanaAdmin is set to true to make it different than users's default
+		// isAdmin value
 		{
 			user: newUser("foo", 0),
 			groups: config.Groups{
 				"foo": {
+					GrafanaAdmin: true,
 					Orgs: []config.Org{
 						{
 							ID:   1,

--- a/pkg/grafana/mock.go
+++ b/pkg/grafana/mock.go
@@ -5,17 +5,19 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockGAPIClient mimicks the behaviour of required gapi calls
 type mockGAPIClient struct {
-	user       *gapi.User
+	user       gapi.User
 	orgRoleMap userOrgsRoleMap
+	mock.Mock
 }
 
 func (c *mockGAPIClient) UserByEmail(login string) (gapi.User, error) {
 	if c.user.Login == login {
-		return *c.user, nil
+		return c.user, nil
 	}
 
 	return gapi.User{}, errors.New(`body: "User not found"`)
@@ -49,17 +51,16 @@ func (c *mockGAPIClient) UpdateOrgUser(orgID, userID int64, role string) error {
 }
 
 func (c *mockGAPIClient) UpdateUserPermissions(id int64, isAdmin bool) error {
+	args := c.Called(id, isAdmin)
 	if id == 0 {
 		return errors.New("error updating user permissions")
 	}
 
-	c.user.IsAdmin = isAdmin
-
-	return nil
+	return args.Error(0)
 }
 
 // MockClient returns a Client using a mocked GAPIClient underneat
-func NewMockClient(user *gapi.User, orgRoleMap map[int64]models.RoleType) *Client {
+func NewMockClient(user gapi.User, orgRoleMap map[int64]models.RoleType) *Client {
 	return &Client{
 		client: &mockGAPIClient{
 			user:       user,

--- a/pkg/grafana/mock.go
+++ b/pkg/grafana/mock.go
@@ -53,6 +53,8 @@ func (c *mockGAPIClient) UpdateUserPermissions(id int64, isAdmin bool) error {
 		return errors.New("error updating user permissions")
 	}
 
+	c.user.IsAdmin = isAdmin
+
 	return nil
 }
 

--- a/pkg/grafana/mock.go
+++ b/pkg/grafana/mock.go
@@ -9,13 +9,13 @@ import (
 
 // MockGAPIClient mimicks the behaviour of required gapi calls
 type mockGAPIClient struct {
-	user       gapi.User
+	user       *gapi.User
 	orgRoleMap userOrgsRoleMap
 }
 
 func (c *mockGAPIClient) UserByEmail(login string) (gapi.User, error) {
 	if c.user.Login == login {
-		return c.user, nil
+		return *c.user, nil
 	}
 
 	return gapi.User{}, errors.New(`body: "User not found"`)
@@ -57,7 +57,7 @@ func (c *mockGAPIClient) UpdateUserPermissions(id int64, isAdmin bool) error {
 }
 
 // MockClient returns a Client using a mocked GAPIClient underneat
-func NewMockClient(user gapi.User, orgRoleMap map[int64]models.RoleType) *Client {
+func NewMockClient(user *gapi.User, orgRoleMap map[int64]models.RoleType) *Client {
 	return &Client{
 		client: &mockGAPIClient{
 			user:       user,


### PR DESCRIPTION
The current way of handling the global Grafana admin flag per group is flawed as it compares with all possible groups (in case the user is in more than one group) and then it toggles the value if it changed, which most likely be the case because `grafanaAdmin: true` will most likely be in only one of the groups and the other/s will have the default value of `false`.

Changes in this PR uses logic operatios to resolve what's the value of Grafana Admin after traversing all groups and then it updates the value once. 