### PR TITLE
Set user information based on all jwt claims

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,6 +36,8 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().String("cookie-name", "auth_token", "Cookie name with jwt token. If set will take precedence over auth header")
 	cmd.PersistentFlags().String("admin-user", "admin", "Admin user")
 	cmd.PersistentFlags().String("admin-password", "", "Admin password")
+	cmd.PersistentFlags().String("jwt-claim-login", "email", "JWT claim to be used as user Login in Grafana. Valid values are 'email' or 'sub'")
+	cmd.PersistentFlags().String("jwt-claim-name", "sub", "JWT claim to be used as user Name in Grafana. Valid values are 'email' or 'sub'")
 
 	return cmd
 }
@@ -87,6 +89,14 @@ func defaultServerOptions() []server.ServerFuncOpt {
 	return opts
 }
 
+func getJWTClaimKey(key string) string {
+	if key == "sub" || key == "email" {
+		return key
+	} else {
+		return ""
+	}
+}
+
 func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 	addr := viper.GetString("listen-address")
 	log.Infof("listening on %s", addr)
@@ -105,6 +115,24 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		log.Error("admin-password is not set")
 		return err
 	}
+
+	loginKey := getJWTClaimKey(viper.GetString("jwt-claim-login"))
+	if loginKey == "" {
+		log.Error("jwt-claim-login can only have a value of \"sub\" or \"email\"")
+		return err
+	}
+
+	nameKey := getJWTClaimKey(viper.GetString("jwt-claim-name"))
+	if nameKey == "" {
+		log.Error("jwt-claim-name can only have a value of \"sub\" or \"email\"")
+		return err
+	}
+
+	claimsMap := server.GrafanaClaimsMap{
+		Login: loginKey,
+		Name:  nameKey,
+	}
+	opts = append(opts, server.WithGrafanaClaimsMap(claimsMap))
 
 	grafanaHTTPClient := http.DefaultClient
 	grafanaHTTPClient.Timeout = viper.GetDuration("http-client-timeout")

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -49,9 +49,9 @@ func WithGrafanaResponseHeaders(headers GrafanaResponseHeaders) ServerFuncOpt {
 	}
 }
 
-func WithGrafanaClaimsMap(claimsMap GrafanaClaimsMap) ServerFuncOpt {
+func WithGrafanaClaimsConfig(config GrafanaClaimsConfig) ServerFuncOpt {
 	return func(s *Server) error {
-		s.grafanaClaimsMap = claimsMap
+		s.grafanaClaimsConfig = config
 		return nil
 	}
 }

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -48,3 +48,10 @@ func WithGrafanaResponseHeaders(headers GrafanaResponseHeaders) ServerFuncOpt {
 		return nil
 	}
 }
+
+func WithGrafanaClaimsMap(claimsMap GrafanaClaimsMap) ServerFuncOpt {
+	return func(s *Server) error {
+		s.grafanaClaimsMap = claimsMap
+		return nil
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,11 @@ type GrafanaResponseHeaders struct {
 	User string
 }
 
+type GrafanaClaimsMap struct {
+	Login string
+	Name  string
+}
+
 type Server struct {
 	router                 *http.ServeMux
 	cookieName             string
@@ -25,6 +30,7 @@ type Server struct {
 	grafanaProxyUrl        *url.URL
 	grafanaClient          *grafana.Client
 	grafanaResponseHeaders GrafanaResponseHeaders
+	grafanaClaimsMap       GrafanaClaimsMap
 	skipTLSVerify          bool
 }
 
@@ -68,8 +74,14 @@ func (s *Server) handleRoot() http.HandlerFunc {
 			return
 		}
 
-		// Make Subject claim the value used for login
-		login := claims.Subject
+		var login string
+		// possible values of Login claim are checked in cli beforehand
+		switch s.grafanaClaimsMap.Login {
+		case "sub":
+			login = claims.Subject
+		case "email":
+			login = claims.Email
+		}
 
 		log.Infof("user %s is attempting to log in", login)
 		log.Debugf("claim groups for user %s: %v", login, claims.Groups)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,7 +18,7 @@ type GrafanaResponseHeaders struct {
 	User string
 }
 
-type GrafanaClaimsMap struct {
+type GrafanaClaimsConfig struct {
 	Login string
 	Name  string
 }
@@ -30,7 +30,7 @@ type Server struct {
 	grafanaProxyUrl        *url.URL
 	grafanaClient          *grafana.Client
 	grafanaResponseHeaders GrafanaResponseHeaders
-	grafanaClaimsMap       GrafanaClaimsMap
+	grafanaClaimsConfig    GrafanaClaimsConfig
 	skipTLSVerify          bool
 }
 
@@ -85,12 +85,9 @@ func (s *Server) handleRoot() http.HandlerFunc {
 		}
 
 		// possible values of Login claim are checked in cli beforehand
-		login := getValidClaim(claims, s.grafanaClaimsMap.Login)
-		name := getValidClaim(claims, s.grafanaClaimsMap.Name)
-		var email string
-		if claims.Email != "" {
-			email = claims.Email
-		}
+		login := getValidClaim(claims, s.grafanaClaimsConfig.Login)
+		name := getValidClaim(claims, s.grafanaClaimsConfig.Name)
+		email := claims.Email
 
 		log.Infof("user %s is attempting to log in", login)
 		log.Debugf("claim groups for user %s: %v", login, claims.Groups)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -140,7 +140,7 @@ func TestHandleRoot(t *testing.T) {
 		WithGrafanaResponseHeaders(GrafanaResponseHeaders{
 			User: "X-WEBAUTH-USER",
 		}),
-		WithGrafanaClaimsMap(GrafanaClaimsMap{
+		WithGrafanaClaimsConfig(GrafanaClaimsConfig{
 			Login: "sub",
 		}),
 	)
@@ -186,11 +186,22 @@ func TestGetValidClaim(t *testing.T) {
 	}
 	claims.Subject = "jhon.doe"
 
-	input := "sub"
-	out := getValidClaim(claims, input)
-	assert.Equal(t, claims.Subject, out)
+	tests := []struct {
+		claimKey string
+		expected string
+	}{
+		{
+			claimKey: "sub",
+			expected: claims.Subject,
+		},
+		{
+			claimKey: "email",
+			expected: claims.Email,
+		},
+	}
 
-	input = "email"
-	out = getValidClaim(claims, input)
-	assert.Equal(t, claims.Email, out)
+	for _, test := range tests {
+		value := getValidClaim(claims, test.claimKey)
+		assert.Equal(t, test.expected, value)
+	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -176,3 +176,18 @@ func TestHandleHealthz(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
+
+func TestGetValidClaim(t *testing.T) {
+	claims := &jwt.Claims{
+		Email: fmt.Sprintf("%s@example.com", "jhon.doe"),
+	}
+	claims.Subject = "jhon.doe"
+
+	input := "sub"
+	out := getValidClaim(claims, input)
+	assert.Equal(t, claims.Subject, out)
+
+	input = "email"
+	out = getValidClaim(claims, input)
+	assert.Equal(t, claims.Email, out)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -140,6 +140,9 @@ func TestHandleRoot(t *testing.T) {
 		WithGrafanaResponseHeaders(GrafanaResponseHeaders{
 			User: "X-WEBAUTH-USER",
 		}),
+		WithGrafanaClaimsMap(GrafanaClaimsMap{
+			Login: "sub",
+		}),
 	)
 	assert.NoError(t, err)
 

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -172,7 +172,7 @@ func (c *Client) UpdateOrgUserAuthz(user gapi.User, groups config.Groups) (userO
 	return userOrgsRole, nil
 }
 
-func (c *Client) GetOrCreateUser(login string) (gapi.User, error) {
+func (c *Client) GetOrCreateUser(login, name, email string) (gapi.User, error) {
 	// lookup the user globally first as if it is not present it would need to
 	// be created
 	user, err := c.LookupUser(login)
@@ -183,6 +183,8 @@ func (c *Client) GetOrCreateUser(login string) (gapi.User, error) {
 	// if the Login field in user is empty, it means that the user wasn't found
 	if user.Login == "" {
 		user.Login = login
+		user.Name = name
+		user.Email = email
 
 		uid, err := c.CreateUser(user)
 		if err != nil {

--- a/pkg/grafana/client_test.go
+++ b/pkg/grafana/client_test.go
@@ -320,16 +320,19 @@ func TestGetOrCreateUser(t *testing.T) {
 
 	client := NewMockClient(user, userOrgsRoleMap{})
 
-	orgUser, err := client.GetOrCreateUser("foo")
+	// Existing users, only Login is used for lookup
+	orgUser, err := client.GetOrCreateUser("foo", "", "")
 	assert.NoError(t, err)
 	assert.Equal(t, user, orgUser)
 
 	// New user
-	newUser, err := client.GetOrCreateUser("new")
+	newUser, err := client.GetOrCreateUser("new", "foo", "bar@foo.com")
 	assert.NoError(t, err)
 	// for convenience the CreateUser mock returns the same ID as the user.ID
 	// passed in NewMockClient
 	assert.Equal(t, int64(1), newUser.ID)
+	assert.Equal(t, "foo", newUser.Name)
+	assert.Equal(t, "bar@foo.com", newUser.Email)
 }
 
 func TestIsRoleAssignable(t *testing.T) {


### PR DESCRIPTION
This change adds new flags to configure what jwt claims to use to set user's Login and Name in Grafana.

Updated tests accordingly.