### PR TITLE
Feature: support getting token from other sources more than cookie

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,7 +37,6 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().String("grafana-user-header", "X-WEBAUTH-USER", "Header to containing the user to authenticate")
 	cmd.PersistentFlags().String("cookie-name", "auth_token", "Name of http Cookie containing the jwt token")
 	cmd.PersistentFlags().String("header-name", "Authorization", "Name of http header containing the jwt token")
-	cmd.PersistentFlags().StringSlice("jwt-containers", []string{"cookie", "header"}, "Slice of jwt containers to try, in order")
 	cmd.PersistentFlags().String("admin-user", "admin", "Admin user")
 	cmd.PersistentFlags().String("admin-password", "", "Admin password")
 	cmd.PersistentFlags().String("jwt-claim-login", "email", "JWT claim to be used as user Login in Grafana. Valid values are 'email' or 'sub'")
@@ -85,19 +84,13 @@ func defaultServerOptions() []server.ServerFuncOpt {
 		User: viper.GetString("grafana-user-header"),
 	}
 
-	jwtContainers := viper.GetStringSlice("jwt-containers")
-
-	// HACK: Viper doesn't set the slice correctly when using an env variable
-	// so it ends up with a string containing commas at index 0
-	if strings.Contains(jwtContainers[0], ",") {
-		jwtContainers = strings.Split(jwtContainers[0], ",")
-	}
-
-	containers := buildJWTContainers(jwtContainers)
-
+	// Cookies are checked first and then header
 	opts := []server.ServerFuncOpt{
 		server.WithGrafanaResponseHeaders(responseHeaders),
-		server.WithTokenContainers(containers),
+		server.WithTokenContainers(
+			jwt.NewCookieContainer(viper.GetString("cookie-name")),
+			jwt.NewHeaderContainer(viper.GetString("header-name")),
+		),
 	}
 
 	return opts
@@ -109,21 +102,6 @@ func isValidClaimKey(key string) error {
 	} else {
 		return fmt.Errorf("%s can only have a value of \"sub\" or \"email\"", key)
 	}
-}
-
-func buildJWTContainers(jwtContainers []string) []jwt.TokenContainer {
-	var output []jwt.TokenContainer
-
-	for _, ctype := range jwtContainers {
-		switch ctype {
-		case "cookie":
-			output = append(output, jwt.NewCookieContainer(viper.GetString("cookie-name")))
-		case "header":
-			output = append(output, jwt.NewHeaderContainer(viper.GetString("header-name")))
-		}
-	}
-
-	return output
 }
 
 func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {

--- a/internal/jwt/container.go
+++ b/internal/jwt/container.go
@@ -24,6 +24,10 @@ func (c *CookieContainer) Get(req *http.Request) (string, error) {
 		return "", err
 	}
 
+	if cookie.Value == "" {
+		return "", fmt.Errorf("cookie %s has empty value", cookie.Name)
+	}
+
 	return cookie.Value, nil
 }
 
@@ -38,9 +42,8 @@ func NewHeaderContainer(headerName string) *HeaderContainer {
 func (h *HeaderContainer) Get(req *http.Request) (string, error) {
 	value := req.Header.Get(h.headerName)
 
-	if strings.HasPrefix(value, "Bearer") {
-		value = strings.TrimPrefix(value, "Bearer ")
-	}
+	// strip Bearer prefix if present
+	value = strings.TrimPrefix(value, "Bearer ")
 
 	if value == "" {
 		return "", fmt.Errorf("no header %s found", h.headerName)

--- a/internal/jwt/container.go
+++ b/internal/jwt/container.go
@@ -1,0 +1,64 @@
+package jwt
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type TokenContainer interface {
+	Get(req *http.Request) (string, error)
+}
+
+type CookieContainer struct {
+	cookieName string
+}
+
+func NewCookieContainer(cookieName string) *CookieContainer {
+	return &CookieContainer{cookieName: cookieName}
+}
+
+func (c *CookieContainer) Get(req *http.Request) (string, error) {
+	cookie, err := req.Cookie(c.cookieName)
+	if err != nil {
+		return "", err
+	}
+
+	return cookie.Value, nil
+}
+
+type HeaderContainer struct {
+	headerName string
+}
+
+func NewHeaderContainer(headerName string) *HeaderContainer {
+	return &HeaderContainer{headerName: headerName}
+}
+
+func (h *HeaderContainer) Get(req *http.Request) (string, error) {
+	value := req.Header.Get(h.headerName)
+
+	if strings.HasPrefix(value, "Bearer") {
+		value = strings.TrimPrefix(value, "Bearer ")
+	}
+
+	if value == "" {
+		return "", fmt.Errorf("no header %s found", h.headerName)
+	}
+
+	return value, nil
+}
+
+func GetFirstFromContainers(req *http.Request, containers []TokenContainer) (string, error) {
+	var token string
+	var err error
+
+	for _, container := range containers {
+		token, err = container.Get(req)
+		if token != "" {
+			break
+		}
+	}
+
+	return token, err
+}

--- a/internal/jwt/container.go
+++ b/internal/jwt/container.go
@@ -58,7 +58,7 @@ func GetFirstFromContainers(req *http.Request, containers []TokenContainer) (str
 
 	for _, container := range containers {
 		token, err = container.Get(req)
-		if token != "" {
+		if token != "" && err == nil {
 			break
 		}
 	}

--- a/internal/jwt/container_test.go
+++ b/internal/jwt/container_test.go
@@ -1,0 +1,129 @@
+package jwt
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCookieContainer(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	cl := Claims{}
+	cl.Subject = "jhon.doe"
+
+	token, _ := NewTestJWTWithClaims(cl)
+
+	req.AddCookie(&http.Cookie{
+		Name:  "auth_token",
+		Value: token,
+	})
+
+	container := NewCookieContainer("auth_token")
+	got, err := container.Get(req)
+	assert.NoError(t, err)
+	assert.Equal(t, got, token)
+}
+
+func TestHeaderContainer(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	cl := Claims{}
+	cl.Subject = "jhon.doe"
+
+	token, _ := NewTestJWTWithClaims(cl)
+
+	req.Header.Add("Authorization", token)
+
+	container := NewHeaderContainer("Authorization")
+	got, err := container.Get(req)
+	assert.NoError(t, err)
+	assert.Equal(t, got, token)
+}
+
+func TestGetFirstFromContainers(t *testing.T) {
+	cookieName := "auth_token"
+	headerName := "Authorization"
+
+	cl := Claims{}
+	cl.Subject = "jhon.doe"
+	token, _ := NewTestJWTWithClaims(cl)
+
+	tests := []struct {
+		containers []TokenContainer
+		withCookie bool
+		withHeader bool
+		want       string
+		err        error
+	}{
+		// With Cookie only
+		{
+			containers: []TokenContainer{
+				NewCookieContainer(cookieName),
+			},
+			withCookie: true,
+			want:       token,
+			err:        nil,
+		},
+		// With Header only
+		{
+			containers: []TokenContainer{
+				NewHeaderContainer(headerName),
+			},
+			withHeader: true,
+			want:       token,
+			err:        nil,
+		},
+		// values in both containers
+		{
+			containers: []TokenContainer{
+				NewCookieContainer(cookieName),
+				NewHeaderContainer(headerName),
+			},
+			withCookie: true,
+			withHeader: true,
+			want:       token,
+			err:        nil,
+		},
+		// value in only one container
+		{
+			containers: []TokenContainer{
+				NewCookieContainer(cookieName),
+				NewHeaderContainer(headerName),
+			},
+			withCookie: false,
+			withHeader: true,
+			want:       token,
+			err:        nil,
+		},
+		// failure in both containers, error comes from last container that failed
+		{
+			containers: []TokenContainer{
+				NewCookieContainer(cookieName),
+				NewHeaderContainer(headerName),
+			},
+			withCookie: false,
+			withHeader: false,
+			want:       "",
+			err:        errors.New("no header Authorization found"),
+		},
+	}
+
+	for _, test := range tests {
+		req := httptest.NewRequest("GET", "/", nil)
+		if test.withCookie {
+			req.AddCookie(&http.Cookie{
+				Name:  cookieName,
+				Value: token,
+			})
+		}
+		if test.withHeader {
+			req.Header.Add(headerName, token)
+		}
+
+		result, err := GetFirstFromContainers(req, test.containers)
+		assert.Equal(t, err, test.err)
+		assert.Equal(t, test.want, result)
+	}
+}

--- a/internal/jwt/container_test.go
+++ b/internal/jwt/container_test.go
@@ -35,7 +35,7 @@ func setupRequestWithCookie(token string) *http.Request {
 
 func setupRequestWithHeader(token string) *http.Request {
 	req := httptest.NewRequest("GET", "/", nil)
-	req.Header.Add(headerName, token)
+	req.Header.Add(headerName, fmt.Sprintf("Bearer %s", token))
 	return req
 }
 
@@ -131,7 +131,7 @@ func TestGetFirstFromContainers(t *testing.T) {
 			})
 		}
 		if test.withHeader {
-			req.Header.Add(headerName, token)
+			req.Header.Add(headerName, fmt.Sprintf("Bearer %s", token))
 		}
 
 		result, err := GetFirstFromContainers(req, test.containers)

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -3,16 +3,17 @@ package server
 import (
 	"net/url"
 
+	"github.com/kanopy-platform/grafana-auth-proxy/internal/jwt"
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/config"
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/grafana"
 )
 
-func WithCookieName(cookie string) ServerFuncOpt {
-	return func(s *Server) error {
-		s.cookieName = cookie
-		return nil
-	}
-}
+// func WithCookieName(cookie string) ServerFuncOpt {
+// 	return func(s *Server) error {
+// 		s.cookieName = cookie
+// 		return nil
+// 	}
+// }
 
 func WithConfigGroups(groups config.Groups) ServerFuncOpt {
 	return func(s *Server) error {
@@ -52,6 +53,13 @@ func WithGrafanaResponseHeaders(headers GrafanaResponseHeaders) ServerFuncOpt {
 func WithGrafanaClaimsConfig(config GrafanaClaimsConfig) ServerFuncOpt {
 	return func(s *Server) error {
 		s.grafanaClaimsConfig = config
+		return nil
+	}
+}
+
+func WithTokenContainers(containers []jwt.TokenContainer) ServerFuncOpt {
+	return func(s *Server) error {
+		s.tokenContainers = containers
 		return nil
 	}
 }

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -8,13 +8,6 @@ import (
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/grafana"
 )
 
-// func WithCookieName(cookie string) ServerFuncOpt {
-// 	return func(s *Server) error {
-// 		s.cookieName = cookie
-// 		return nil
-// 	}
-// }
-
 func WithConfigGroups(groups config.Groups) ServerFuncOpt {
 	return func(s *Server) error {
 		s.groups = groups

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -50,9 +50,9 @@ func WithGrafanaClaimsConfig(config GrafanaClaimsConfig) ServerFuncOpt {
 	}
 }
 
-func WithTokenContainers(containers []jwt.TokenContainer) ServerFuncOpt {
+func WithTokenContainers(containers ...jwt.TokenContainer) ServerFuncOpt {
 	return func(s *Server) error {
-		s.tokenContainers = containers
+		s.tokenContainers = append(s.tokenContainers, containers...)
 		return nil
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,6 +123,10 @@ func (s *Server) handleRoot() http.HandlerFunc {
 		r.Header.Set("X-Forwarded-Host", r.Host)
 		r.Header.Set(s.grafanaResponseHeaders.User, login)
 
+		// remove any Authorization header from the request as if not Grafana will try to process it and fail
+		// calls to the Grafana API must use Grafana minted auth tokens, not /login ones
+		r.Header.Del("Authorization")
+
 		// Create the reverse proxy
 		proxy := httputil.NewSingleHostReverseProxy(s.grafanaProxyUrl)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -84,7 +84,7 @@ func TestTokenValidations(t *testing.T) {
 
 		server, err := New(
 			WithGrafanaProxyURL(backendURL),
-			WithTokenContainers([]jwt.TokenContainer{jwt.NewCookieContainer(test.cookie.Name)}),
+			WithTokenContainers(jwt.NewCookieContainer(test.cookie.Name)),
 			WithConfigGroups(config.Groups{}),
 			WithGrafanaClient(client),
 			WithGrafanaResponseHeaders(GrafanaResponseHeaders{
@@ -134,7 +134,7 @@ func TestHandleRoot(t *testing.T) {
 
 	server, err := New(
 		WithGrafanaProxyURL(backendURL),
-		WithTokenContainers([]jwt.TokenContainer{jwt.NewCookieContainer("auth_token")}),
+		WithTokenContainers(jwt.NewCookieContainer("auth_token")),
 		WithConfigGroups(groups),
 		WithGrafanaClient(client),
 		WithGrafanaResponseHeaders(GrafanaResponseHeaders{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -84,7 +84,7 @@ func TestTokenValidations(t *testing.T) {
 
 		server, err := New(
 			WithGrafanaProxyURL(backendURL),
-			WithCookieName(test.cookie.Name),
+			WithTokenContainers([]jwt.TokenContainer{jwt.NewCookieContainer(test.cookie.Name)}),
 			WithConfigGroups(config.Groups{}),
 			WithGrafanaClient(client),
 			WithGrafanaResponseHeaders(GrafanaResponseHeaders{
@@ -134,7 +134,7 @@ func TestHandleRoot(t *testing.T) {
 
 	server, err := New(
 		WithGrafanaProxyURL(backendURL),
-		WithCookieName("auth_token"),
+		WithTokenContainers([]jwt.TokenContainer{jwt.NewCookieContainer("auth_token")}),
 		WithConfigGroups(groups),
 		WithGrafanaClient(client),
 		WithGrafanaResponseHeaders(GrafanaResponseHeaders{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -158,6 +158,7 @@ func TestHandleRoot(t *testing.T) {
 	assert.Equal(t, "http://grafana.example.com", req.Header.Get("X-Forwarded-Host"))
 	assert.Equal(t, "jhon", req.Header.Get("X-WEBAUTH-USER"))
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, req.Header.Get("Authorization"))
 }
 
 func TestHandleHealthz(t *testing.T) {


### PR DESCRIPTION
This PR adds support for using custom "token containers" from http requests.

Getting the token from cookie has been reimplemented in a CookieContainer and support to get the token from an arbitrary header (defaulting to Authorization) has been added too.

In the cli, the order of containers is fixed to try first a cookie and then a header if the cookie fails.

Usage of containers is a fallthrough process, if there's more than one container listed, it will try them in order and the first one returning a valid value will be used to retrieve the jwt token.