### PR TITLE
Strip Authorization header before proxying

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -124,6 +124,9 @@ func (s *Server) handleRoot() http.HandlerFunc {
 		r.Header.Set("X-Forwarded-Host", r.Host)
 		r.Header.Set(s.grafanaResponseHeaders.User, login)
 
+		// Remove the Authorization header as it's not needed anymore and will conflict with Grafana's API access
+		r.Header.Del("Authorization")
+
 		// Create the reverse proxy
 		proxy := httputil.NewSingleHostReverseProxy(s.grafanaProxyUrl)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -154,9 +154,13 @@ func TestHandleRoot(t *testing.T) {
 		Value: newTestJWTToken("jhon"),
 	})
 
+	// Verify that if an Authorization header is present, it's correctly removed
+	req.Header.Add("Authorization", "something")
+
 	server.ServeHTTP(w, req)
 	assert.Equal(t, "http://grafana.example.com", req.Header.Get("X-Forwarded-Host"))
 	assert.Equal(t, "jhon", req.Header.Get("X-WEBAUTH-USER"))
+	assert.Equal(t, "", req.Header.Get("Authorization"))
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 


### PR DESCRIPTION
This is required in order to avoid passing an Authorization header to Grafana when using the auth-proxy, if not, Grafana will try to read the Authorization header and think is a token to access its API