### PR TITLE
Remove ignored k8s-auth-portal license

### DIFF
--- a/.licensed.yaml
+++ b/.licensed.yaml
@@ -14,6 +14,4 @@ reviewed:
     - golang.org/x/**/* # bsd-style
     - gopkg.in/ini.v1 # apache-2.0
     - gopkg.in/yaml.v2 # apache-2.0
-ignored:
-  go:
-    - github.com/kanopy-platform/k8s-auth-portal/**/* # no-license
+    - github.com/kanopy-platform/k8s-auth-portal/**/* # apache-2.0

--- a/NOTICE
+++ b/NOTICE
@@ -4252,6 +4252,23 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 
 *****
+github.com/kanopy-platform/k8s-auth-portal/pkg/random@v0.1.4
+
+Copyright 2022 MongoDB Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*****
 github.com/magiconair/properties@v1.8.5
 
 Copyright (c) 2013-2020, Frank Schroeder

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
 	github.com/grafana/grafana-api-golang-client v0.1.0
-	github.com/kanopy-platform/k8s-auth-portal v0.1.0
+	github.com/kanopy-platform/k8s-auth-portal v0.1.4
 	github.com/sirupsen/logrus v1.8.1
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -206,6 +207,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kanopy-platform/k8s-auth-portal v0.1.0 h1:qKoTx50g8FkWgA4DqXz0KOU4F5Z3w5mDHbN0mGgzT3E=
 github.com/kanopy-platform/k8s-auth-portal v0.1.0/go.mod h1:UGHaJELJTCu04hKPQwZvI3FoULB2XnJ0WHDasesNAAs=
+github.com/kanopy-platform/k8s-auth-portal v0.1.4 h1:QfuOzCXRtbSBrb5akOEwC61YTfgpO3Ogx6S59bJm82Y=
+github.com/kanopy-platform/k8s-auth-portal v0.1.4/go.mod h1:8o6EpQxvo8w1zclzbBhNeJGUgEjz0FfHIgezTKXOq08=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,6 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kanopy-platform/k8s-auth-portal v0.1.0 h1:qKoTx50g8FkWgA4DqXz0KOU4F5Z3w5mDHbN0mGgzT3E=
-github.com/kanopy-platform/k8s-auth-portal v0.1.0/go.mod h1:UGHaJELJTCu04hKPQwZvI3FoULB2XnJ0WHDasesNAAs=
 github.com/kanopy-platform/k8s-auth-portal v0.1.4 h1:QfuOzCXRtbSBrb5akOEwC61YTfgpO3Ogx6S59bJm82Y=
 github.com/kanopy-platform/k8s-auth-portal v0.1.4/go.mod h1:8o6EpQxvo8w1zclzbBhNeJGUgEjz0FfHIgezTKXOq08=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
The k8s-auth-portal project includes a LICENSE since v0.1.4.

I don't think we need to cut a release just for this, but wanted to have the change reflected in the repo at least.