### PR TITLE
log usage details after proxying

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,13 +188,12 @@ func (s *Server) handleRoot() http.HandlerFunc {
 
 		// Log request details after proxying
 		log.WithFields(log.Fields{
-			"method":     r.Method,
-			"path":       r.URL.Path,
-			"status":     rw.statusCode,
-			"user_login": login,
-			"user_email": email,
-			"user_sub":   claims.Subject,
-		}).Info("request proxied to Grafana")
+			"method":      r.Method,
+			"path":        r.URL.Path,
+			"status":      rw.statusCode,
+			"user_email":  email,
+			"user_sub":    claims.Subject,
+		}).Info("request proxied to grafana")
 	}
 }
 
@@ -215,6 +214,8 @@ func (s *Server) handleHealthz() http.HandlerFunc {
 }
 
 func logAndError(w http.ResponseWriter, code int, err error, msg string) {
-	log.WithError(err).Error(msg)
+	log.WithError(err).WithFields(log.Fields{
+		"status": code,
+	}).Error(msg)
 	http.Error(w, http.StatusText(code), code)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -102,7 +102,7 @@ func (s *Server) handleRoot() http.HandlerFunc {
 			token = r.Header.Get(s.headerName)
 			// replicate the cookie look up behavior for a missing header
 			if token == "" {
-				logAndError(w, http.StatusUnauthorized, fmt.Errorf("No value for header %s", s.headerName), "error reading header")
+				logAndError(w, http.StatusUnauthorized, fmt.Errorf("no value for header %s", s.headerName), "error reading header")
 				return
 			}
 		} else {
@@ -209,7 +209,7 @@ func (s *Server) handleHealthz() http.HandlerFunc {
 			return
 		}
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprint(w, string(bytes))
+		_, _ = fmt.Fprint(w, string(bytes))
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,6 +35,35 @@ type Server struct {
 	skipTLSVerify          bool
 }
 
+// responseWriter wraps http.ResponseWriter to capture the status code
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{
+		ResponseWriter: w,
+		statusCode:     0, // 0 means not set yet
+	}
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	if rw.statusCode == 0 {
+		rw.statusCode = code
+	}
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	// If WriteHeader hasn't been called yet, status code defaults to 200
+	// (Go's http package behavior)
+	if rw.statusCode == 0 {
+		rw.statusCode = http.StatusOK
+	}
+	return rw.ResponseWriter.Write(b)
+}
+
 type ServerFuncOpt func(*Server) error
 
 func New(opts ...ServerFuncOpt) (http.Handler, error) {
@@ -140,6 +169,9 @@ func (s *Server) handleRoot() http.HandlerFunc {
 		// Remove the Authorization header as it's not needed anymore and will conflict with Grafana's API access
 		r.Header.Del("Authorization")
 
+		// Wrap the response writer to capture status code
+		rw := newResponseWriter(w)
+
 		// Create the reverse proxy
 		proxy := httputil.NewSingleHostReverseProxy(s.grafanaProxyUrl)
 
@@ -151,7 +183,18 @@ func (s *Server) handleRoot() http.HandlerFunc {
 			}
 		}
 
-		proxy.ServeHTTP(w, r)
+		// Proxy the request
+		proxy.ServeHTTP(rw, r)
+
+		// Log request details after proxying
+		log.WithFields(log.Fields{
+			"method":     r.Method,
+			"path":       r.URL.Path,
+			"status":     rw.statusCode,
+			"user_login": login,
+			"user_email": email,
+			"user_sub":   claims.Subject,
+		}).Info("request proxied to Grafana")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,11 +188,11 @@ func (s *Server) handleRoot() http.HandlerFunc {
 
 		// Log request details after proxying
 		log.WithFields(log.Fields{
-			"method":      r.Method,
-			"path":        r.URL.Path,
-			"status":      rw.statusCode,
-			"user_email":  email,
-			"user_sub":    claims.Subject,
+			"method":     r.Method,
+			"path":       r.URL.Path,
+			"status":     rw.statusCode,
+			"user_email": email,
+			"user_sub":   claims.Subject,
 		}).Info("request proxied to grafana")
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kanopy-platform/grafana-auth-proxy/internal/jwt"
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/config"
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/grafana"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -255,5 +256,145 @@ func TestGetValidClaim(t *testing.T) {
 	for _, test := range tests {
 		value := getValidClaim(claims, test.claimKey)
 		assert.Equal(t, test.expected, value)
+	}
+}
+
+// testHook is a logrus hook that captures log entries for testing
+type testHook struct {
+	entries []*log.Entry
+}
+
+func (h *testHook) Levels() []log.Level {
+	return []log.Level{log.InfoLevel, log.ErrorLevel, log.DebugLevel}
+}
+
+func (h *testHook) Fire(entry *log.Entry) error {
+	h.entries = append(h.entries, entry)
+	return nil
+}
+
+func TestRequestLogging(t *testing.T) {
+	// Set up a test hook to capture log entries
+	hook := &testHook{entries: []*log.Entry{}}
+	log.AddHook(hook)
+	defer func() {
+		// Clean up - remove the hook by resetting the standard logger
+		log.StandardLogger().ReplaceHooks(make(log.LevelHooks))
+	}()
+
+	// Create a backend server that returns different status codes
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/datasources/1" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, `{"id": 1}`)
+		} else if r.URL.Path == "/api/dashboards/notfound" {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintln(w, `{"message": "not found"}`)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, "Hello, client")
+		}
+	}))
+	defer backendServer.Close()
+	backendURL, _ := url.Parse(backendServer.URL)
+
+	groups := config.Groups{
+		"foo": {
+			Orgs: []config.Org{
+				{
+					ID:   1,
+					Role: "Editor",
+				},
+			},
+		},
+	}
+
+	orgRoleMap := map[int64]grafana.RoleType{
+		1: grafana.ROLE_EDITOR,
+	}
+
+	client := grafana.NewMockClient(gapi.User{Login: "testuser", ID: 1}, orgRoleMap)
+
+	server, err := New(
+		WithGrafanaProxyURL(backendURL),
+		WithCookieName("auth_token"),
+		WithConfigGroups(groups),
+		WithGrafanaClient(client),
+		WithGrafanaResponseHeaders(GrafanaResponseHeaders{
+			User: "X-WEBAUTH-USER",
+		}),
+		WithGrafanaClaimsConfig(GrafanaClaimsConfig{
+			Login: "sub",
+		}),
+	)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		expectedStatus int
+		expectedUser   string
+		expectedEmail  string
+		expectedGroups []string
+	}{
+		{
+			name:           "GET request to datasource",
+			method:         "GET",
+			path:           "/api/datasources/1",
+			expectedStatus: http.StatusOK,
+			expectedUser:   "testuser",
+			expectedEmail:  "testuser@example.com",
+			expectedGroups: []string{"foo", "bar"},
+		},
+		{
+			name:           "POST request with 404 response",
+			method:         "POST",
+			path:           "/api/dashboards/notfound",
+			expectedStatus: http.StatusNotFound,
+			expectedUser:   "testuser",
+			expectedEmail:  "testuser@example.com",
+			expectedGroups: []string{"foo", "bar"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Clear previous log entries
+			hook.entries = []*log.Entry{}
+
+			req := httptest.NewRequest(test.method, test.path, nil)
+			req.Host = "http://grafana.example.com"
+			req.AddCookie(&http.Cookie{
+				Name:  "auth_token",
+				Value: newTestJWTToken("testuser"),
+			})
+
+			w := httptest.NewRecorder()
+			server.ServeHTTP(w, req)
+
+			assert.Equal(t, test.expectedStatus, w.Code)
+
+			// Find the log entry for "request proxied to Grafana"
+			var logEntry *log.Entry
+			for _, entry := range hook.entries {
+				if entry.Message == "request proxied to grafana" {
+					logEntry = entry
+					break
+				}
+			}
+
+			assert.NotNil(t, logEntry, "Expected log entry 'request proxied to Grafana' not found")
+			if logEntry == nil {
+				return
+			}
+
+			// Verify all required fields are present (using the changed field names)
+			assert.Equal(t, test.method, logEntry.Data["method"], "method field should match")
+			assert.Equal(t, test.path, logEntry.Data["path"], "path field should match")
+			assert.Equal(t, test.expectedStatus, logEntry.Data["status"], "status field should match")
+			assert.Equal(t, test.expectedEmail, logEntry.Data["user_email"], "user_email field should match")
+			assert.Equal(t, "testuser", logEntry.Data["user_sub"], "user_sub field should match")
+		})
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -33,7 +33,7 @@ func TestTokenValidations(t *testing.T) {
 	// the backendServer represents the Grafana server. In this case we are mocking the Grafana api calls
 	// so the backend server is only here to avoid the proxy to timeout
 	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Hello, client")
+		_, _ = fmt.Fprintln(w, "Hello, client")
 	}))
 	defer backendServer.Close()
 	backendURL, _ := url.Parse(backendServer.URL)
@@ -159,7 +159,7 @@ func TestHandleRoot(t *testing.T) {
 	// the backendServer represents the Grafana server. In this case we are mocking the Grafana api calls
 	// so the backend server is only here to avoid the proxy to timeout
 	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Hello, client")
+		_, _ = fmt.Fprintln(w, "Hello, client")
 	}))
 	defer backendServer.Close()
 	backendURL, _ := url.Parse(backendServer.URL)
@@ -284,15 +284,16 @@ func TestRequestLogging(t *testing.T) {
 
 	// Create a backend server that returns different status codes
 	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/datasources/1" {
+		switch r.URL.Path {
+		case "/api/datasources/1":
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, `{"id": 1}`)
-		} else if r.URL.Path == "/api/dashboards/notfound" {
+			_, _ = fmt.Fprintln(w, `{"id": 1}`)
+		case "/api/dashboards/notfound":
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprintln(w, `{"message": "not found"}`)
-		} else {
+			_, _ = fmt.Fprintln(w, `{"message": "not found"}`)
+		default:
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, "Hello, client")
+			_, _ = fmt.Fprintln(w, "Hello, client")
 		}
 	}))
 	defer backendServer.Close()


### PR DESCRIPTION
Modifies the behavior of the proxy server so that it logs information about the request and the user making the request. Since the ask is to include the request code, this change wraps the response writer to capture the written response code.

