### PR TITLE
Add ordered multi-header JWT extraction with backwards compatibility

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -35,7 +35,8 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().String("grafana-proxy-url", "http://grafana.example.com", "Grafana url to proxy to")
 	cmd.PersistentFlags().String("grafana-user-header", "X-WEBAUTH-USER", "Header to containing the user to authenticate")
 	cmd.PersistentFlags().String("cookie-name", "auth_token", "Cookie name with jwt token. If set will take precedence over auth header")
-	cmd.PersistentFlags().String("header-name", "", "header name with jwt token. If set will take precedence over cookie-name")
+	cmd.PersistentFlags().String("header-name", "", "header name with jwt token. If set will take precedence over cookie-name. Deprecated: use header-names instead")
+	cmd.PersistentFlags().StringSlice("header-names", []string{}, "ordered list of header names to check for a jwt token (first non-empty wins). Takes precedence over header-name. The 'Bearer ' prefix is stripped automatically.")
 	cmd.PersistentFlags().String("admin-user", "admin", "Admin user")
 	cmd.PersistentFlags().String("admin-password", "", "Admin password")
 	cmd.PersistentFlags().String("jwt-claim-login", "email", "JWT claim to be used as user Login in Grafana. Valid values are 'email' or 'sub'. Falls back to 'sub' if the configured claim is empty.")
@@ -78,6 +79,23 @@ func (c *RootCommand) persistentPreRunE(cmd *cobra.Command, args []string) error
 	return nil
 }
 
+// normalizeHeaderNames trims whitespace, drops empty entries, and splits any
+// comma-separated values. This ensures both YAML lists and env vars like
+// APP_HEADER_NAMES=X-Test-Header,Authorization are handled correctly,
+// since Viper's GetStringSlice passes env var strings through as a single element.
+func normalizeHeaderNames(headers []string) []string {
+	var out []string
+	for _, h := range headers {
+		for part := range strings.SplitSeq(h, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
+
 func defaultServerOptions() []server.ServerFuncOpt {
 	responseHeaders := server.GrafanaResponseHeaders{
 		User: viper.GetString("grafana-user-header"),
@@ -85,9 +103,17 @@ func defaultServerOptions() []server.ServerFuncOpt {
 
 	opts := []server.ServerFuncOpt{
 		server.WithCookieName(viper.GetString("cookie-name")),
-		server.WithHeaderName(viper.GetString("header-name")),
-		server.WithGrafanaResponseHeaders(responseHeaders),
 	}
+
+	// header-names takes precedence; fall back to the singular header-name for
+	// backwards compatibility with existing deployments.
+	if headerNames := normalizeHeaderNames(viper.GetStringSlice("header-names")); len(headerNames) > 0 {
+		opts = append(opts, server.WithHeaderNames(headerNames))
+	} else if headerName := viper.GetString("header-name"); headerName != "" {
+		opts = append(opts, server.WithHeaderName(headerName))
+	}
+
+	opts = append(opts, server.WithGrafanaResponseHeaders(responseHeaders))
 
 	return opts
 }

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/config"
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/grafana"
@@ -14,9 +15,32 @@ func WithCookieName(cookie string) ServerFuncOpt {
 	}
 }
 
+// WithHeaderName appends a single header name to the ordered list of headers
+// consulted when extracting a JWT token. It is kept for backwards compatibility;
+// prefer WithHeaderNames when configuring multiple headers.
 func WithHeaderName(header string) ServerFuncOpt {
 	return func(s *Server) error {
-		s.headerName = header
+		if header = strings.TrimSpace(header); header != "" {
+			s.headerNames = append(s.headerNames, header)
+		}
+		return nil
+	}
+}
+
+// WithHeaderNames sets (replaces) the ordered list of header names to consult
+// when extracting a JWT token. The first header that contains a non-empty value
+// is used; the Bearer scheme is stripped automatically so both bare-JWT headers
+// and standard Authorization headers work. Empty and whitespace-only entries
+// are silently dropped.
+func WithHeaderNames(headers []string) ServerFuncOpt {
+	return func(s *Server) error {
+		filtered := make([]string, 0, len(headers))
+		for _, h := range headers {
+			if h = strings.TrimSpace(h); h != "" {
+				filtered = append(filtered, h)
+			}
+		}
+		s.headerNames = filtered
 		return nil
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 
 	"github.com/kanopy-platform/grafana-auth-proxy/internal/jwt"
 	"github.com/kanopy-platform/grafana-auth-proxy/pkg/config"
@@ -26,7 +27,7 @@ type GrafanaClaimsConfig struct {
 type Server struct {
 	router                 *http.ServeMux
 	cookieName             string
-	headerName             string
+	headerNames            []string
 	groups                 config.Groups
 	grafanaProxyUrl        *url.URL
 	grafanaClient          *grafana.Client
@@ -83,6 +84,18 @@ func New(opts ...ServerFuncOpt) (http.Handler, error) {
 	return s.router, nil
 }
 
+// extractToken strips the Bearer auth scheme from a header value if present.
+// Matching is case-insensitive and surrounding whitespace is trimmed, so
+// "bearer <jwt>", "Bearer  <jwt>", and trailing spaces all work correctly.
+// A bare JWT is returned unchanged.
+func extractToken(v string) string {
+	v = strings.TrimSpace(v)
+	if len(v) > 7 && strings.EqualFold(v[:6], "bearer") && v[6] == ' ' {
+		return strings.TrimSpace(v[7:])
+	}
+	return v
+}
+
 func getValidClaim(claims *jwt.Claims, input string) string {
 	switch input {
 	case "sub":
@@ -98,11 +111,18 @@ func (s *Server) handleRoot() http.HandlerFunc {
 		// Get token
 		var token string
 
-		if s.headerName != "" {
-			token = r.Header.Get(s.headerName)
-			// replicate the cookie look up behavior for a missing header
+		if len(s.headerNames) > 0 {
+			// Try each configured header in order; use the first non-empty value.
+			// The "Bearer " prefix is stripped unconditionally so that both bare JWTs
+			// and standard Authorization headers work without additional configuration.
+			for _, h := range s.headerNames {
+				if v := r.Header.Get(h); v != "" {
+					token = extractToken(v)
+					break
+				}
+			}
 			if token == "" {
-				logAndError(w, http.StatusUnauthorized, fmt.Errorf("no value for header %s", s.headerName), "error reading header")
+				logAndError(w, http.StatusUnauthorized, fmt.Errorf("no value in any configured header: %v", s.headerNames), "error reading header")
 				return
 			}
 		} else {
@@ -170,7 +190,13 @@ func (s *Server) handleRoot() http.HandlerFunc {
 		r.Header.Set("X-Forwarded-Host", r.Host)
 		r.Header.Set(s.grafanaResponseHeaders.User, login)
 
-		// Remove the Authorization header as it's not needed anymore and will conflict with Grafana's API access
+		// Remove all configured auth headers — they have served their purpose and
+		// must not be forwarded to Grafana. Authorization is also removed
+		// unconditionally to cover the legacy single-header-name path and to
+		// prevent conflicts with Grafana's own API access.
+		for _, h := range s.headerNames {
+			r.Header.Del(h)
+		}
 		r.Header.Del("Authorization")
 
 		// Wrap the response writer to capture status code

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -163,6 +163,177 @@ func TestTokenValidations(t *testing.T) {
 	}
 }
 
+func TestMultiHeaderNames(t *testing.T) {
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, "Hello, client")
+	}))
+	defer backendServer.Close()
+	backendURL, _ := url.Parse(backendServer.URL)
+
+	aliceToken := newTestJWTToken("alice")
+	bobToken := newTestJWTToken("bob")
+	invalidToken := "this-is-no-valid-jwt"
+
+	clientAlice := grafana.NewMockClient(gapi.User{Login: "alice", ID: 1}, map[int64]grafana.RoleType{})
+	clientBob := grafana.NewMockClient(gapi.User{Login: "bob", ID: 2}, map[int64]grafana.RoleType{})
+
+	baseOpts := func(client *grafana.Client) []ServerFuncOpt {
+		return []ServerFuncOpt{
+			WithGrafanaProxyURL(backendURL),
+			WithConfigGroups(config.Groups{}),
+			WithGrafanaClient(client),
+			WithGrafanaResponseHeaders(GrafanaResponseHeaders{User: "X-WEBAUTH-USER"}),
+			WithHeaderNames([]string{"X-Test-Header", "Authorization"}),
+		}
+	}
+
+	t.Run("first header present and valid — identity from first token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Test-Header", aliceToken)
+		s, err := New(baseOpts(clientAlice)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "alice", req.Header.Get("X-WEBAUTH-USER"))
+	})
+
+	t.Run("second header present and valid bare JWT — identity from second token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", bobToken)
+		s, err := New(baseOpts(clientBob)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "bob", req.Header.Get("X-WEBAUTH-USER"))
+	})
+
+	t.Run("second header with Bearer prefix stripped — identity from second token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer "+bobToken)
+		s, err := New(baseOpts(clientBob)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "bob", req.Header.Get("X-WEBAUTH-USER"))
+	})
+
+	t.Run("lowercase bearer prefix stripped — identity from second token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "bearer "+bobToken)
+		s, err := New(baseOpts(clientBob)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "bob", req.Header.Get("X-WEBAUTH-USER"))
+	})
+
+	t.Run("first header wins when both present — identity is first token's subject", func(t *testing.T) {
+		// alice in first header, bob (with Bearer) in second: alice must win.
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Test-Header", aliceToken)
+		req.Header.Set("Authorization", "Bearer "+bobToken)
+		s, err := New(baseOpts(clientAlice)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "alice", req.Header.Get("X-WEBAUTH-USER"))
+	})
+
+	t.Run("first header present but invalid does not fall through to second header", func(t *testing.T) {
+		// Priority is positional: first non-empty header value is used even if the JWT is invalid.
+		// This prevents an attacker supplying a valid Authorization header from bypassing a
+		// rejected, alternative token.
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Test-Header", invalidToken)
+		req.Header.Set("Authorization", "Bearer "+aliceToken)
+		s, err := New(baseOpts(clientAlice)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("no configured headers present returns unauthorized", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		s, err := New(baseOpts(clientAlice)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("bare JWT header has no Bearer prefix — extractToken is a no-op", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Test-Header", aliceToken)
+		s, err := New(baseOpts(clientAlice)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "alice", req.Header.Get("X-WEBAUTH-USER"))
+	})
+
+	t.Run("configured auth headers are removed before proxying", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Test-Header", aliceToken)
+		req.Header.Set("Authorization", "Bearer "+bobToken)
+		s, err := New(baseOpts(clientAlice)...)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "", req.Header.Get("X-Test-Header"), "X-Test-Header should be removed before proxying")
+		assert.Equal(t, "", req.Header.Get("Authorization"), "Authorization should be removed before proxying")
+	})
+
+	t.Run("empty entries in WithHeaderNames do not disable cookie fallback", func(t *testing.T) {
+		// WithHeaderNames([]string{""}) should produce an empty headerNames slice,
+		// so the server falls back to cookies as if no headers were configured.
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{Name: "auth_token", Value: aliceToken})
+		s, err := New(
+			WithGrafanaProxyURL(backendURL),
+			WithConfigGroups(config.Groups{}),
+			WithGrafanaClient(clientAlice),
+			WithGrafanaResponseHeaders(GrafanaResponseHeaders{User: "X-WEBAUTH-USER"}),
+			WithCookieName("auth_token"),
+			WithHeaderNames([]string{"", "  ", ""}), // all empty/whitespace — should be filtered
+		)
+		assert.NoError(t, err)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "alice", req.Header.Get("X-WEBAUTH-USER"))
+	})
+}
+
+func TestExtractToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"bare JWT unchanged", "eyJhbGc.eyJzdW.sig", "eyJhbGc.eyJzdW.sig"},
+		{"Bearer prefix stripped", "Bearer eyJhbGc.eyJzdW.sig", "eyJhbGc.eyJzdW.sig"},
+		{"lowercase bearer stripped", "bearer eyJhbGc.eyJzdW.sig", "eyJhbGc.eyJzdW.sig"},
+		{"mixed case Bearer stripped", "BEARER eyJhbGc.eyJzdW.sig", "eyJhbGc.eyJzdW.sig"},
+		{"extra space after Bearer stripped", "Bearer  eyJhbGc.eyJzdW.sig", "eyJhbGc.eyJzdW.sig"},
+		{"leading/trailing whitespace trimmed", "  Bearer eyJhbGc.eyJzdW.sig  ", "eyJhbGc.eyJzdW.sig"},
+		{"bare JWT with surrounding whitespace trimmed", "  eyJhbGc.eyJzdW.sig  ", "eyJhbGc.eyJzdW.sig"},
+		{"Basic scheme not stripped", "Basic dXNlcjpwYXNz", "Basic dXNlcjpwYXNz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractToken(tt.input))
+		})
+	}
+}
+
 func TestHandleRoot(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Replaces the single `--header-name` flag with `--header-names` (a `StringSlice`), allowing operators to configure an ordered list of headers to check for a JWT token. The first non-empty header value wins; if `--header-names` is not set, the legacy `--header-name` is used as before.

Key details:
- `extractToken` strips the `Bearer ` scheme case-insensitively, so both bare-JWT headers (e.g. `X-Alternate-Token`) and standard `Authorization` headers work without extra configuration.
- `normalizeHeaderNames` in `cli.go` splits comma-separated values so env-var assignment (`APP_HEADER_NAMES=h1,h2`) works correctly, working around Viper's `GetStringSlice` behaviour with plain strings.
- All configured auth headers are removed before proxying; `Authorization` is always removed unconditionally to cover the legacy path and to not conflict with Grafana's API access.
- `WithHeaderName` is preserved as a backwards-compatible option that appends a single entry to the ordered list.
- New `TestMultiHeaderNames` and `TestExtractToken` suites cover first-wins priority, Bearer stripping, fallback, and header cleanup.